### PR TITLE
Set version range on requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+libprogress<=3.0.1
+libnamegen<=3.0.2

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-          'libprogress',
-          'libnamegen',
+          'libprogress<=3.0.1',
+          'libnamegen<=3.0.2',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This application now has a version range set on dependencies in case the dependencies are updated in a non backwards-compatible way before this application can be updated.